### PR TITLE
Release for v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.0.0](https://github.com/handlename/awsc/compare/v0.1.0...v0.0.0) - 2024-10-25
+## [v0.2.0](https://github.com/handlename/awsc/compare/v0.1.0...v0.2.0) - 2024-10-25
 - Confirm on modify resources by @handlename in https://github.com/handlename/awsc/pull/3
 - test by go 1.23 by @handlename in https://github.com/handlename/awsc/pull/4
 - AccountOptionWithAdditionalInfo should not return error by @handlename in https://github.com/handlename/awsc/pull/5
@@ -9,3 +9,5 @@
 - Show version by @handlename in https://github.com/handlename/awsc/pull/8
 
 ## [v0.1.0](https://github.com/handlename/awsc/commits/v0.1.0) - 2024-10-14
+
+- First release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [v0.0.0](https://github.com/handlename/awsc/compare/v0.1.0...v0.0.0) - 2024-10-25
+- Confirm on modify resources by @handlename in https://github.com/handlename/awsc/pull/3
+- test by go 1.23 by @handlename in https://github.com/handlename/awsc/pull/4
+- AccountOptionWithAdditionalInfo should not return error by @handlename in https://github.com/handlename/awsc/pull/5
+- Switch default template depending on additional info flag by @handlename in https://github.com/handlename/awsc/pull/6
+- Explain confirm_on_modify in README by @handlename in https://github.com/handlename/awsc/pull/7
+- Show version by @handlename in https://github.com/handlename/awsc/pull/8
+
+## [v0.1.0](https://github.com/handlename/awsc/commits/v0.1.0) - 2024-10-14

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package awsc
 
-const Version = "0.0.0"
+const Version = "0.2.0"


### PR DESCRIPTION
This pull request is for the next release as v0.0.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.1.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Confirm on modify resources by @handlename in https://github.com/handlename/awsc/pull/3
* test by go 1.23 by @handlename in https://github.com/handlename/awsc/pull/4
* AccountOptionWithAdditionalInfo should not return error by @handlename in https://github.com/handlename/awsc/pull/5
* Switch default template depending on additional info flag by @handlename in https://github.com/handlename/awsc/pull/6
* Explain confirm_on_modify in README by @handlename in https://github.com/handlename/awsc/pull/7
* Show version by @handlename in https://github.com/handlename/awsc/pull/8

## New Contributors
* @handlename made their first contribution in https://github.com/handlename/awsc/pull/3

**Full Changelog**: https://github.com/handlename/awsc/compare/v0.1.0...v0.0.0