### PR TITLE
Release for v0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v0.2.1](https://github.com/handlename/awsc/compare/v0.2.0...v0.2.1) - 2024-12-23
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.27.43 to 1.28.5 by @dependabot in https://github.com/handlename/awsc/pull/16
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/service/sts from 1.33.1 to 1.33.3 by @dependabot in https://github.com/handlename/awsc/pull/18
+- chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.32.5 to 1.32.7 by @dependabot in https://github.com/handlename/awsc/pull/19
+- chore(deps): bump github.com/stretchr/testify from 1.9.0 to 1.10.0 by @dependabot in https://github.com/handlename/awsc/pull/14
+- chore(deps): bump github.com/fatih/color from 1.17.0 to 1.18.0 by @dependabot in https://github.com/handlename/awsc/pull/12
+- Use "require" instead of "assert" by @handlename in https://github.com/handlename/awsc/pull/20
+
 ## [v0.2.0](https://github.com/handlename/awsc/compare/v0.1.0...v0.2.0) - 2024-10-25
 - Confirm on modify resources by @handlename in https://github.com/handlename/awsc/pull/3
 - test by go 1.23 by @handlename in https://github.com/handlename/awsc/pull/4

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package awsc
 
-const Version = "0.2.0"
+const Version = "0.2.1"


### PR DESCRIPTION
This pull request is for the next release as v0.2.1 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.1 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.27.43 to 1.28.5 by @dependabot in https://github.com/handlename/awsc/pull/16
* chore(deps): bump github.com/aws/aws-sdk-go-v2/service/sts from 1.33.1 to 1.33.3 by @dependabot in https://github.com/handlename/awsc/pull/18
* chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.32.5 to 1.32.7 by @dependabot in https://github.com/handlename/awsc/pull/19
* chore(deps): bump github.com/stretchr/testify from 1.9.0 to 1.10.0 by @dependabot in https://github.com/handlename/awsc/pull/14
* chore(deps): bump github.com/fatih/color from 1.17.0 to 1.18.0 by @dependabot in https://github.com/handlename/awsc/pull/12
* Use "require" instead of "assert" by @handlename in https://github.com/handlename/awsc/pull/20

## New Contributors
* @dependabot made their first contribution in https://github.com/handlename/awsc/pull/16

**Full Changelog**: https://github.com/handlename/awsc/compare/v0.2.0...v0.2.1