### PR TITLE
Show detailed error when unexpected file exists in config path

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -71,6 +71,14 @@ func Test_determineConfigPath(t *testing.T) {
 			},
 			want: filepath.Join(testdataRoot, "home2", ".awsc", "config.yaml"),
 		},
+		{
+			name: "a file is placed in path than expects a directory",
+			env: map[string]string{
+				"HOME": filepath.Join(testdataRoot, "home3"),
+			},
+			wantErr: true,
+			errBody: "expects a directory",
+		},
 	}
 
 	for _, tt := range tests {
@@ -82,6 +90,13 @@ func Test_determineConfigPath(t *testing.T) {
 			}
 
 			path, err := determineConigPath()
+
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.errBody)
+				return
+			}
+
 			require.NoError(t, err)
 			assert.Equal(t, tt.want, path)
 		})


### PR DESCRIPTION
before

```console
❯ AWS_PROFILE=private awsc sts get-caller-identity
======== error ========
code = Internal
message = failed to stat
callstack = cli.determineConigPath: cli.Run: main.main: runtime.main: goexit
cause = not a directory

======== detail ========
[cli.determineConigPath] /home/runner/work/awsc/awsc/cli/cli.go:83
    Internal
    failed to stat
    {path=awsc/config.yaml}
*fs.PathError("stat awsc/config.yaml: not a directory")
syscall.Errno("not a directory")
[CallStack]
    [cli.determineConigPath] /home/runner/work/awsc/awsc/cli/cli.go:83
    [cli.Run] /home/runner/work/awsc/awsc/cli/cli.go:37
    [main.main] /home/runner/work/awsc/awsc/cmd/awsc/main.go:10
    [runtime.main] /opt/hostedtoolcache/go/1.23.4/x64/src/runtime/proc.go:272
    [runtime.goexit] /opt/hostedtoolcache/go/1.23.4/x64/src/runtime/asm_arm64.s:1223
```

after

```console
❯ AWS_PROFILE=private awsc sts get-caller-identity
======== error ========
code = Internal
message = a file is placed in path than expects a directory
callstack = cli.determineConigPath: cli.Run: main.main: runtime.main: goexit
cause = not a directory

======== detail ========
[cli.determineConigPath] /home/runner/work/awsc/awsc/cli/cli.go:89
    Internal
    a file is placed in path than expects a directory
    {path=awsc/config.yaml}
*fs.PathError("stat awsc/config.yaml: not a directory")
syscall.Errno("not a directory")
[CallStack]
    [cli.determineConigPath] /home/runner/work/awsc/awsc/cli/cli.go:89
    [cli.Run] /home/runner/work/awsc/awsc/cli/cli.go:39
    [main.main] /home/runner/work/awsc/awsc/cmd/awsc/main.go:10
    [runtime.main] /opt/hostedtoolcache/go/1.23.4/x64/src/runtime/proc.go:272
    [runtime.goexit] /opt/hostedtoolcache/go/1.23.4/x64/src/runtime/asm_arm64.s:1223
```

diff

```diff
--- before.txt
+++ after.txt
@@ -1,20 +1,20 @@
 ❯ AWS_PROFILE=private awsc sts get-caller-identity
 ======== error ========
 code = Internal
-message = failed to stat
+message = a file is placed in path than expects a directory
 callstack = cli.determineConigPath: cli.Run: main.main: runtime.main: goexit
 cause = not a directory

 ======== detail ========
-[cli.determineConigPath] /home/runner/work/awsc/awsc/cli/cli.go:83
+[cli.determineConigPath] /home/runner/work/awsc/awsc/cli/cli.go:89
     Internal
-    failed to stat
+    a file is placed in path than expects a directory
     {path=awsc/config.yaml}
 *fs.PathError("stat awsc/config.yaml: not a directory")
 syscall.Errno("not a directory")
 [CallStack]
-    [cli.determineConigPath] /home/runner/work/awsc/awsc/cli/cli.go:83
-    [cli.Run] /home/runner/work/awsc/awsc/cli/cli.go:37
+    [cli.determineConigPath] /home/runner/work/awsc/awsc/cli/cli.go:89
+    [cli.Run] /home/runner/work/awsc/awsc/cli/cli.go:39
     [main.main] /home/runner/work/awsc/awsc/cmd/awsc/main.go:10
     [runtime.main] /opt/hostedtoolcache/go/1.23.4/x64/src/runtime/proc.go:272
     [runtime.goexit] /opt/hostedtoolcache/go/1.23.4/x64/src/runtime/asm_arm64.s:1223
```