### PR TITLE
Release for v0.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.2.3](https://github.com/handlename/awsc/compare/v0.2.2...v0.2.3) - 2025-03-03
+- Fix XDG_CONFIG_PATH by @handlename in https://github.com/handlename/awsc/pull/25
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.28.5 to 1.28.7 by @dependabot in https://github.com/handlename/awsc/pull/27
+- chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.32.7 to 1.36.0 by @dependabot in https://github.com/handlename/awsc/pull/28
+- group dependabot pull requests for aws-sdk-go-v2 by @handlename in https://github.com/handlename/awsc/pull/36
+- chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.28.7 to 1.29.8 by @dependabot in https://github.com/handlename/awsc/pull/35
+
 ## [v0.2.2](https://github.com/handlename/awsc/compare/v0.2.1...v0.2.2) - 2024-12-27
 - Use XDG_CONFIG_HOME by @handlename in https://github.com/handlename/awsc/pull/21
 - Show detailed error when unexpected file exists in config path by @handlename in https://github.com/handlename/awsc/pull/23

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package awsc
 
-const Version = "0.2.2"
+const Version = "0.2.3"


### PR DESCRIPTION
This pull request is for the next release as v0.2.3 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.2.3 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.2" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Fix XDG_CONFIG_PATH by @handlename in https://github.com/handlename/awsc/pull/25
* chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.28.5 to 1.28.7 by @dependabot in https://github.com/handlename/awsc/pull/27
* chore(deps): bump github.com/aws/aws-sdk-go-v2 from 1.32.7 to 1.36.0 by @dependabot in https://github.com/handlename/awsc/pull/28
* group dependabot pull requests for aws-sdk-go-v2 by @handlename in https://github.com/handlename/awsc/pull/36
* chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.28.7 to 1.29.8 by @dependabot in https://github.com/handlename/awsc/pull/35


**Full Changelog**: https://github.com/handlename/awsc/compare/v0.2.2...v0.2.3