### PR TITLE
group dependabot pull requests for aws-sdk-go-v2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,9 @@ updates:
   directory: "/"
   schedule:
     interval: monthly
+  groups:
+    dependencies:
+      patterns:
+        - "github.com/aws/aws-sdk-go-v2"
+        - "github.com/aws/aws-sdk-go-v2/*"
   open-pull-requests-limit: 10


### PR DESCRIPTION
[Grouped version updates for Dependabot public beta \- GitHub Changelog](https://github.blog/changelog/2023-06-30-grouped-version-updates-for-dependabot-public-beta/)
[Dependabot options reference \- GitHub Docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--)