### PR TITLE
Release for v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [v0.3.0](https://github.com/handlename/awsc/compare/v0.2.3...v0.3.0) - 2025-08-02
+- chore(deps): bump github.com/rs/zerolog from 1.33.0 to 1.34.0 by @dependabot[bot] in https://github.com/handlename/awsc/pull/38
+- chore(deps): bump the dependencies group with 2 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/37
+- chore(deps): bump the dependencies group with 2 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/40
+- chore(deps): bump the dependencies group with 3 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/41
+- chore(deps): bump the dependencies group with 3 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/42
+
 ## [v0.2.3](https://github.com/handlename/awsc/compare/v0.2.2...v0.2.3) - 2025-03-03
 - Fix XDG_CONFIG_PATH by @handlename in https://github.com/handlename/awsc/pull/25
 - chore(deps): bump github.com/aws/aws-sdk-go-v2/config from 1.28.5 to 1.28.7 by @dependabot in https://github.com/handlename/awsc/pull/27

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package awsc
 
-const Version = "0.2.3"
+const Version = "0.3.0"


### PR DESCRIPTION
This pull request is for the next release as v0.3.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.2.3" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps): bump github.com/rs/zerolog from 1.33.0 to 1.34.0 by @dependabot[bot] in https://github.com/handlename/awsc/pull/38
* chore(deps): bump the dependencies group with 2 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/37
* chore(deps): bump the dependencies group with 2 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/40
* chore(deps): bump the dependencies group with 3 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/41
* chore(deps): bump the dependencies group with 3 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/42


**Full Changelog**: https://github.com/handlename/awsc/compare/v0.2.3...v0.3.0