### PR TITLE
Release for v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [v0.4.0](https://github.com/handlename/awsc/compare/v0.3.0...v0.4.0) - 2025-10-05
+- chore(deps): bump github.com/stretchr/testify from 1.10.0 to 1.11.1 by @dependabot[bot] in https://github.com/handlename/awsc/pull/43
+- chore(deps): bump the dependencies group with 3 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/44
+- chore(deps): bump the dependencies group with 3 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/46
+- chore: Configure Renovate by @renovate[bot] in https://github.com/handlename/awsc/pull/47
+- chore(deps): update actions/checkout action to v5 by @renovate[bot] in https://github.com/handlename/awsc/pull/48
+- Pin actions by @handlename in https://github.com/handlename/awsc/pull/51
+- Use latest stable Go by @handlename in https://github.com/handlename/awsc/pull/52
+- chore(deps): update actions/setup-go action to v6 by @renovate[bot] in https://github.com/handlename/awsc/pull/49
+- chore(deps): update goreleaser/goreleaser-action action to v6 by @renovate[bot] in https://github.com/handlename/awsc/pull/54
+- chore(deps): update songmu/tagpr action to v1.9.0 by @renovate[bot] in https://github.com/handlename/awsc/pull/53
+
 ## [v0.3.0](https://github.com/handlename/awsc/compare/v0.2.3...v0.3.0) - 2025-08-02
 - chore(deps): bump github.com/rs/zerolog from 1.33.0 to 1.34.0 by @dependabot[bot] in https://github.com/handlename/awsc/pull/38
 - chore(deps): bump the dependencies group with 2 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/37

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [v0.4.0](https://github.com/handlename/awsc/compare/v0.3.0...v0.4.0) - 2025-10-05
+## [v0.3.1](https://github.com/handlename/awsc/compare/v0.3.0...v0.3.1) - 2025-10-05
 - chore(deps): bump github.com/stretchr/testify from 1.10.0 to 1.11.1 by @dependabot[bot] in https://github.com/handlename/awsc/pull/43
 - chore(deps): bump the dependencies group with 3 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/44
 - chore(deps): bump the dependencies group with 3 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/46

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package awsc
 
-const Version = "0.3.0"
+const Version = "0.4.0"

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package awsc
 
-const Version = "0.4.0"
+const Version = "0.3.1"


### PR DESCRIPTION
This pull request is for the next release as v0.4.0 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.4.0 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.0" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps): bump github.com/stretchr/testify from 1.10.0 to 1.11.1 by @dependabot[bot] in https://github.com/handlename/awsc/pull/43
* chore(deps): bump the dependencies group with 3 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/44
* chore(deps): bump the dependencies group with 3 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/46
* chore: Configure Renovate by @renovate[bot] in https://github.com/handlename/awsc/pull/47
* chore(deps): update actions/checkout action to v5 by @renovate[bot] in https://github.com/handlename/awsc/pull/48
* Pin actions by @handlename in https://github.com/handlename/awsc/pull/51
* Use latest stable Go by @handlename in https://github.com/handlename/awsc/pull/52
* chore(deps): update actions/setup-go action to v6 by @renovate[bot] in https://github.com/handlename/awsc/pull/49
* chore(deps): update goreleaser/goreleaser-action action to v6 by @renovate[bot] in https://github.com/handlename/awsc/pull/54
* chore(deps): update songmu/tagpr action to v1.9.0 by @renovate[bot] in https://github.com/handlename/awsc/pull/53

## New Contributors
* @renovate[bot] made their first contribution in https://github.com/handlename/awsc/pull/47

**Full Changelog**: https://github.com/handlename/awsc/compare/v0.3.0...tagpr-from-v0.3.0