### PR TITLE
Release for v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.3.2](https://github.com/handlename/awsc/compare/v0.3.1...v0.3.2) - 2025-10-05
+- Make release immutable by @handlename in https://github.com/handlename/awsc/pull/55
+
 ## [v0.3.1](https://github.com/handlename/awsc/compare/v0.3.0...v0.3.1) - 2025-10-05
 - chore(deps): bump github.com/stretchr/testify from 1.10.0 to 1.11.1 by @dependabot[bot] in https://github.com/handlename/awsc/pull/43
 - chore(deps): bump the dependencies group with 3 updates by @dependabot[bot] in https://github.com/handlename/awsc/pull/44

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package awsc
 
-const Version = "0.3.1"
+const Version = "0.3.2"


### PR DESCRIPTION
This pull request is for the next release as v0.3.2 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.2 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.1" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* Make release immutable by @handlename in https://github.com/handlename/awsc/pull/55


**Full Changelog**: https://github.com/handlename/awsc/compare/v0.3.1...tagpr-from-v0.3.1