### PR TITLE
Release for v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.3.5](https://github.com/handlename/awsc/compare/v0.3.4...v0.3.5) - 2026-01-11
+- chore(deps): update songmu/tagpr action to v1.11.0 by @renovate[bot] in https://github.com/handlename/awsc/pull/73
+- fix(deps): update aws-sdk-go-v2 monorepo by @renovate[bot] in https://github.com/handlename/awsc/pull/74
+
 ## [v0.3.4](https://github.com/handlename/awsc/compare/v0.3.3...v0.3.4) - 2025-12-20
 - chore(deps): update actions/checkout action to v6.0.1 by @renovate[bot] in https://github.com/handlename/awsc/pull/68
 - fix(deps): update aws-sdk-go-v2 monorepo by @renovate[bot] in https://github.com/handlename/awsc/pull/66

--- a/version.go
+++ b/version.go
@@ -1,3 +1,3 @@
 package awsc
 
-const Version = "0.3.4"
+const Version = "0.3.5"


### PR DESCRIPTION
This pull request is for the next release as v0.3.5 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.3.5 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.3.4" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* chore(deps): update songmu/tagpr action to v1.11.0 by @renovate[bot] in https://github.com/handlename/awsc/pull/73
* fix(deps): update aws-sdk-go-v2 monorepo by @renovate[bot] in https://github.com/handlename/awsc/pull/74


**Full Changelog**: https://github.com/handlename/awsc/compare/v0.3.4...tagpr-from-v0.3.4